### PR TITLE
APP-44646 Added support for configurable domain to segment pendo inte…

### DIFF
--- a/integrations/pendo/lib/index.js
+++ b/integrations/pendo/lib/index.js
@@ -17,9 +17,9 @@ var obj = require('obj-case');
 var Pendo = (module.exports = integration('Pendo')
   .global('pendo')
   .option('apiKey', '')
-  .tag(
-    '<script src="https://cdn.pendo.io/agent/static/{{ apiKey }}/pendo.js">'
-  ));
+  .option('domain', 'cdn.pendo.io')
+  .tag('<script src="https://{{ domain }}/agent/static/{{ apiKey }}/pendo.js">')
+);
 
 /**
  * Either use this as a TagLoader and all the relevant Pendo information will

--- a/integrations/pendo/package.json
+++ b/integrations/pendo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pendo",
   "description": "The Pendo analytics.js integration.",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Add support for configurable domain.

**Are there breaking changes in this PR?**
No.

**Testing**
standard integration testing

**Any background context you want to provide?**
No.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**
It uses one if provided. The new setting would be the domain used to host the pendo.js file. Specifically the domain is the only thing adjustable; the scheme, path, port, etc will not be affected by this.

**Links to helpful docs and other external resources**
